### PR TITLE
Add support for web authoring

### DIFF
--- a/src/lib/TableauEmbed/TableauViz.tsx
+++ b/src/lib/TableauEmbed/TableauViz.tsx
@@ -65,6 +65,7 @@ export interface OptionalTableauVizProps {
 
 export interface TableauVizCustomProps extends OptionalTableauVizProps {
   src: string;
+  isAuthoring?: boolean;
 }
 
 declare global {
@@ -75,6 +76,11 @@ declare global {
         HTMLElement
       > &
       TableauVizCustomProps;
+      ["tableau-authoring-viz"]: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      > &
+      TableauVizCustomProps;      
       [VizChildElements.VizFilter]: FilterParameters;
       [VizChildElements.VizParameter]: VizParameter;
       [VizChildElements.CustomParameter]: CustomParameter;
@@ -276,6 +282,10 @@ function TableauViz(props: TableauVizCustomProps, ref: TableauVizRef) {
     }
     return () => { };
   }, [vizRef]);
+
+  if (props.isAuthoring) {
+    return <tableau-authoring-viz id="tableauViz" ref={vizRef} {...props}></tableau-authoring-viz>;
+  }
 
   return <tableau-viz id="tableauViz" ref={vizRef} {...props}></tableau-viz>;
 }

--- a/src/lib/TableauEmbed/UseTableau/index.tsx
+++ b/src/lib/TableauEmbed/UseTableau/index.tsx
@@ -24,6 +24,7 @@ export interface UseTableauParams {
   ref: TableauVizRef;
   sourceUrl: string;
   version?: string;
+  isAuthoring?: boolean;
   optionalProperties?: OptionalTableauVizProps;
 }
 
@@ -54,9 +55,10 @@ export default function useTableau(args: UseTableauParams): UseTableauReturn {
   const tableauVizProps = React.useMemo<TableauVizCustomProps>(
     () => ({
       src: args.sourceUrl,
+      isAuthoring: args.isAuthoring,
       ...args.optionalProperties,
     }),
-    [args.sourceUrl, args.optionalProperties]
+    [args.sourceUrl, args.isAuthoring, args.optionalProperties]
   );
 
   const [status, setStatus] = React.useState<UseTableauStatus>(() => {

--- a/src/lib/TableauEmbed/index.tsx
+++ b/src/lib/TableauEmbed/index.tsx
@@ -9,14 +9,16 @@ interface TableauEmbed extends OptionalTableauVizProps {
   sourceUrl: string;
   version?: string;
   loadingSpinner?: React.ReactElement;
+  isAuthoring?: boolean;
 }
 
 function TableauEmbed(props: TableauEmbed, ref: TableauVizRef) {
-  const { sourceUrl, version, ...optionalProperties } = props;
+  const { sourceUrl, version, isAuthoring, ...optionalProperties } = props;
   const { isSuccess, isError, component, ...tableau } = useTableau({
     ref,
     sourceUrl,
     version,
+    isAuthoring,
     optionalProperties,
   });
 


### PR DESCRIPTION
- add isAuthoring prop to TableauViz
- allows client to use Tableau's web component

Additional info about Tableau embedded web authoring: https://help.tableau.com/current/api/embedding_api/en-us/docs/embedding_api_web_authoring.html
